### PR TITLE
Fix the problem that the level with 3 progress bars is displayed incorrectly at the end of the level

### DIFF
--- a/assets/script/ui/fight/balance.ts
+++ b/assets/script/ui/fight/balance.ts
@@ -89,7 +89,7 @@ export class balance extends Component {
 
         const len = this.progress.length;
         for (let idx = 0; idx < maxProgress; idx++) {
-            if(maxProgress >= len){
+            if(maxProgress > len){
                 break;
             }
 


### PR DESCRIPTION
https://github.com/cocos-creator/3d-tasks/issues/7740
